### PR TITLE
Misc Fixes

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,7 +14,7 @@ import {
   LoadFonts,
   CssVariables,
   CssGlobalDefaults,
-} from "@atomicjolt/atomic-elements";
+} from "../packages/atomic-elements/src/styles";
 
 const preview: Preview = {
   decorators: [

--- a/.storybook/utils/helpers.tsx
+++ b/.storybook/utils/helpers.tsx
@@ -1,8 +1,8 @@
 import { ArgTypes } from "@storybook/react";
 import { createGlobalStyle } from "styled-components";
 import { PressEvents } from "@react-aria/interactions";
-import { Item } from "@atomicjolt/atomic-elements";
 import { OverlayTriggerProps } from "react-stately";
+import { Item } from "../../packages/atomic-elements/src/components";
 
 export const FieldStateControls: ArgTypes = {
   isDisabled: {

--- a/packages/atomic-elements/src/components/Dropdowns/Combobox/ComboBox.component.tsx
+++ b/packages/atomic-elements/src/components/Dropdowns/Combobox/ComboBox.component.tsx
@@ -53,7 +53,7 @@ export const ComboBox = forwardRef(function ComboBox<T extends object>(
         error={error}
         floating={variant === "floating"}
       >
-        <ComboInput padding={["left", "right"]}>
+        <ComboInput padding="both">
           {prefixIcon && (
             <MaterialIcon icon={prefixIcon} variant={iconVariant} />
           )}

--- a/packages/atomic-elements/src/components/Dropdowns/Combobox/__snapshots__/Combobox.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Dropdowns/Combobox/__snapshots__/Combobox.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`matches snapshots > matches default variant 1`] = `
       message
     </p>
     <div
-      class="sc-cEzcPc jcKbmV aje-combo-input padding-left padding-right"
+      class="sc-cEzcPc eDXioh aje-combo-input"
     >
       <input
         aria-autocomplete="list"
@@ -28,7 +28,7 @@ exports[`matches snapshots > matches default variant 1`] = `
         aria-labelledby="react-aria-:r3:"
         autocomplete="off"
         autocorrect="off"
-        class="sc-jtQUzJ xwtGQ is-full"
+        class="sc-jtQUzJ iRCKuE is-full"
         id="react-aria-:r2:"
         role="combobox"
         spellcheck="false"
@@ -66,7 +66,7 @@ exports[`matches snapshots > matches floating variant 1`] = `
       class="sc-eUlrpB imBDzj"
     >
       <div
-        class="sc-cEzcPc jcKbmV aje-combo-input padding-left padding-right"
+        class="sc-cEzcPc eDXioh aje-combo-input"
       >
         <input
           aria-autocomplete="list"
@@ -75,7 +75,7 @@ exports[`matches snapshots > matches floating variant 1`] = `
           aria-labelledby="react-aria-:rc:"
           autocomplete="off"
           autocorrect="off"
-          class="sc-jtQUzJ xwtGQ is-full"
+          class="sc-jtQUzJ iRCKuE is-full"
           id="react-aria-:rb:"
           role="combobox"
           spellcheck="false"

--- a/packages/atomic-elements/src/components/Dropdowns/Menu/Menu.stories.tsx
+++ b/packages/atomic-elements/src/components/Dropdowns/Menu/Menu.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Menu } from ".";
 import { Item, Section } from "@components/Collection";
-import { Flex } from "@components/Layout/Flex/Flex";
 
 export default {
   title: "Dropdowns/Menu/Menu",
@@ -10,8 +9,8 @@ export default {
     (Story) => (
       <div
         style={{
-          border: "1px solid gray",
-          borderRadius: "5px",
+          border: "var(--border)",
+          borderRadius: "var(--radius)",
           padding: "1px",
         }}
       >

--- a/packages/atomic-elements/src/components/Dropdowns/Select/Select.styles.ts
+++ b/packages/atomic-elements/src/components/Dropdowns/Select/Select.styles.ts
@@ -24,9 +24,8 @@ export const StyledSelect = styled.select`
   --input-width-md: 240px;
   --input-width-lg: 360px;
 
-  border: 1px solid var(--input-border-clr);
+  ${mixins.Border("input")}
   background-color: var(--neutral50);
-  border-radius: 5px;
   min-height: 40px;
   width: 100%;
   padding: 10px 40px 10px 12px;

--- a/packages/atomic-elements/src/components/Dropdowns/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Dropdowns/Select/__snapshots__/Select.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`matches snapshot 1`] = `
     >
       <select
         aria-describedby="select-:r0:-message"
-        class="sc-gtLWhw cqqsDw"
+        class="sc-gtLWhw iFoOhS"
         id="select-:r0:-select"
       >
         <option

--- a/packages/atomic-elements/src/components/Fields/Atoms/TextArea/TextArea.styles.ts
+++ b/packages/atomic-elements/src/components/Fields/Atoms/TextArea/TextArea.styles.ts
@@ -3,10 +3,8 @@ import styled from "styled-components";
 
 export const StyledTextArea = styled.textarea`
   ${mixins.Regular}
+  ${mixins.Border("input")}
 
-  border: var(--input-border);
-  border-color: var(--input-border-clr);
-  border-radius: var(--input-border-radius);
   min-height: 80px;
   min-width: 200px;
   height: var(--textarea-height);
@@ -32,6 +30,6 @@ export const StyledTextArea = styled.textarea`
   &:focus {
     box-shadow: 0 0 0 1px var(--input-border-clr);
     outline: var(--input-outline);
-    outline-color: var(--input-border-clr);
+    --input-border-clr: var(--outline-clr-primary);
   }
 `;

--- a/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.component.tsx
+++ b/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.component.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import classNames from "classnames";
 import { ComboInputProps } from "./ComboInput.types";
 import { StyledComboInput } from "./ComboInput.styles";
 import { useContextProps } from "@hooks/useContextProps";
 import { ComboInputContext } from "./ComboInput.context";
+import { useRenderProps } from "@hooks";
 
 /**
  * ComboInput is a wrapper component that allows you present a input-like component
@@ -17,19 +17,22 @@ export const ComboInput = React.forwardRef(function ComboInput(
 ) {
   [props, ref] = useContextProps(ComboInputContext, props, ref);
 
-  const { className, padding = [], children, inputRef, ...rest } = props;
+  const { className, padding, children, inputRef, ...rest } = props;
+
+  const renderProps = useRenderProps({
+    componentClassName: "aje-combo-input",
+    ...props,
+  });
 
   return (
     <StyledComboInput
-      className={classNames("aje-combo-input", className, {
-        "padding-left": padding.includes("left"),
-        "padding-right": padding.includes("right"),
-      })}
       ref={ref}
       onClick={() => inputRef?.current?.focus()}
+      $paddingSide={padding}
       {...rest}
+      {...renderProps}
     >
-      {children}
+      {renderProps.children}
     </StyledComboInput>
   );
 });

--- a/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.styles.ts
+++ b/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.styles.ts
@@ -1,7 +1,8 @@
 import mixins from "@styles/mixins";
 import styled from "styled-components";
+import { PaddingSide } from "./ComboInput.types";
 
-export const StyledComboInput = styled.div`
+export const StyledComboInput = styled.div<{ $paddingSide?: PaddingSide }>`
   ${mixins.Regular}
   ${mixins.InputLike}
   padding: 0px;
@@ -10,13 +11,18 @@ export const StyledComboInput = styled.div`
   gap: var(--input-gap);
   cursor: text;
 
-  &.padding-left {
-    padding-left: var(--input-padding-horiz);
-  }
-
-  &.padding-right {
-    padding-right: var(--input-padding-horiz);
-  }
+  ${({ $paddingSide }) => {
+    if ($paddingSide === "left") {
+      return "padding-left: var(--input-padding-horiz);";
+    } else if ($paddingSide === "right") {
+      return "padding-right: var(--input-padding-horiz);";
+    } else if ($paddingSide === "both") {
+      return `
+        padding-left: var(--input-padding-horiz);
+        padding-right: var(--input-padding-horiz);
+      `;
+    }
+  }}
 
   input {
     border: none;

--- a/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.types.ts
+++ b/packages/atomic-elements/src/components/Fields/ComboInput/ComboInput.types.ts
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react";
 import { BaseProps, HasChildren } from "../../../types";
 
-export type PaddingSide = "left" | "right";
+export type PaddingSide = "left" | "right" | "both";
 
 export interface ComboInputProps
   extends Omit<BaseProps, "size">,
@@ -13,5 +13,5 @@ export interface ComboInputProps
    */
   inputRef?: React.RefObject<HTMLInputElement>;
 
-  padding?: PaddingSide[] | PaddingSide;
+  padding?: PaddingSide;
 }

--- a/packages/atomic-elements/src/components/Inputs/Checkbox/__snapshots__/CheckBox.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/Checkbox/__snapshots__/CheckBox.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`CheckBox > Snapshots > should match snapshot 1`] = `
       type="checkbox"
     />
     <span
-      class="sc-fFoeYl idDpFn"
+      class="sc-fFoeYl iHstjM"
     />
   </div>
 </DocumentFragment>

--- a/packages/atomic-elements/src/components/Inputs/DateAndTimes/DateInput/DateInput.component.tsx
+++ b/packages/atomic-elements/src/components/Inputs/DateAndTimes/DateInput/DateInput.component.tsx
@@ -52,8 +52,8 @@ export function DateInput<T extends DateValue>(props: DateInputProps<T>) {
       <ComboInput
         {...fieldProps}
         ref={ref}
-        className={"aje-input__date-segments"}
-        padding={["left", "right"]}
+        className="aje-input__date-segments"
+        padding="both"
       >
         {state.segments.map((segment, i) => (
           <DateSegment key={i} segment={segment} state={state} />

--- a/packages/atomic-elements/src/components/Inputs/DateAndTimes/DatePicker/DatePicker.component.tsx
+++ b/packages/atomic-elements/src/components/Inputs/DateAndTimes/DatePicker/DatePicker.component.tsx
@@ -60,7 +60,7 @@ export function DatePicker<T extends DateValue>(props: DatePickerProps<T>) {
         {...groupProps}
         ref={ref}
         className={"aje-input__date-segments"}
-        padding={["left", "right"]}
+        padding="both"
       >
         <DateInput {...fieldProps} size="full" isRequired={isRequired} />
         <IconButton icon="today" variant="content" {...buttonProps} />

--- a/packages/atomic-elements/src/components/Inputs/DateAndTimes/TimeInput/TimeInput.component.tsx
+++ b/packages/atomic-elements/src/components/Inputs/DateAndTimes/TimeInput/TimeInput.component.tsx
@@ -46,7 +46,7 @@ export function TimeInput<T extends TimeValue>(props: TimeInputProps<T>) {
         {...fieldProps}
         ref={ref}
         className={"aje-input__date-segments"}
-        padding={["left", "right"]}
+        padding="both"
       >
         {state.segments.map((segment, i) => (
           <DateSegment key={i} segment={segment} state={state} />

--- a/packages/atomic-elements/src/components/Inputs/NumberInput/NumberInput.component.tsx
+++ b/packages/atomic-elements/src/components/Inputs/NumberInput/NumberInput.component.tsx
@@ -47,7 +47,7 @@ export const NumberInput = React.forwardRef(
           message={message}
           error={error}
         >
-          <ComboInput>
+          <ComboInput padding="both">
             <FieldInput />
             <Group direction="column" isMerged>
               <NumberField.IncrementButton

--- a/packages/atomic-elements/src/components/Inputs/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/RadioGroup/__snapshots__/RadioGroup.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`matches snapshot 1`] = `
         value="opt1"
       />
       <span
-        class="sc-blHHSb ikiVSw aje-checkbox__label"
+        class="sc-blHHSb itIOEH aje-checkbox__label"
       >
         Option 1
       </span>
@@ -45,7 +45,7 @@ exports[`matches snapshot 1`] = `
         value="opt2"
       />
       <span
-        class="sc-blHHSb ikiVSw aje-checkbox__label"
+        class="sc-blHHSb itIOEH aje-checkbox__label"
       >
         Option 2
       </span>
@@ -61,7 +61,7 @@ exports[`matches snapshot 1`] = `
         value="opt3"
       />
       <span
-        class="sc-blHHSb ikiVSw aje-checkbox__label"
+        class="sc-blHHSb itIOEH aje-checkbox__label"
       >
         Option 3
       </span>

--- a/packages/atomic-elements/src/components/Inputs/SearchInput/SearchInput.component.tsx
+++ b/packages/atomic-elements/src/components/Inputs/SearchInput/SearchInput.component.tsx
@@ -63,7 +63,7 @@ export const SearchInput = React.forwardRef(function SearchInput(
     <StyledField {...renderProps}>
       {label && <Label {...labelProps}>{label}</Label>}
       {message && <Message {...descriptionProps}>{message}</Message>}
-      <ComboInput>
+      <ComboInput padding="both">
         <Input {...inputProps} size={undefined} />
         <IconButton
           icon="search"

--- a/packages/atomic-elements/src/components/Inputs/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -13,11 +13,11 @@ exports[`matches snapshot > displays with search button 1`] = `
       search
     </label>
     <div
-      class="sc-cHqXqK bjeXUZ aje-combo-input"
+      class="sc-cHqXqK gYPaYd aje-combo-input"
     >
       <input
         aria-labelledby="react-aria-:r6:"
-        class="sc-jwIPbr lmnZFO"
+        class="sc-jwIPbr ePvIDm"
         id="react-aria-:r5:"
         type="search"
         value=""
@@ -51,11 +51,11 @@ exports[`matches snapshot > displays without button 1`] = `
       search
     </label>
     <div
-      class="sc-cHqXqK bjeXUZ aje-combo-input"
+      class="sc-cHqXqK gYPaYd aje-combo-input"
     >
       <input
         aria-labelledby="react-aria-:r1:"
-        class="sc-jwIPbr lmnZFO"
+        class="sc-jwIPbr ePvIDm"
         id="react-aria-:r0:"
         type="search"
         value=""

--- a/packages/atomic-elements/src/components/Inputs/TextAreaInput/__snapshots__/TextAreaInput.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/TextAreaInput/__snapshots__/TextAreaInput.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`matches snapshot 1`] = `
       label
     </label>
     <textarea
-      class="sc-ivxoEo iOavVu"
+      class="sc-ivxoEo dvSywW"
     />
   </div>
 </DocumentFragment>

--- a/packages/atomic-elements/src/components/Inputs/TextInput/__snapshots__/TextInput.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/TextInput/__snapshots__/TextInput.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`matches snapshot > default variant 1`] = `
     <input
       aria-describedby="react-aria-:r3:"
       aria-labelledby="react-aria-:r1:"
-      class="sc-fAUdSK cfCVRY"
+      class="sc-fAUdSK iwDUbw"
       id="react-aria-:r0:"
       placeholder="placeholder"
       type="text"
@@ -43,7 +43,7 @@ exports[`matches snapshot > floating variant 1`] = `
       <input
         aria-describedby="react-aria-:r8:"
         aria-labelledby="react-aria-:r6:"
-        class="sc-fAUdSK cfCVRY"
+        class="sc-fAUdSK iwDUbw"
         data-float="true"
         id="react-aria-:r5:"
         placeholder="placeholder"

--- a/packages/atomic-elements/src/components/Layout/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Layout/Table/__snapshots__/Table.spec.tsx.snap
@@ -35,11 +35,11 @@ exports[`Table > Snapshots > Should match the snapshot when searchable 1`] = `
                 Column 1
                 <div
                   aria-expanded="true"
-                  class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                  class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
                 >
                   <input
                     aria-label="Search a"
-                    class="sc-fAUdSK cfCVRY"
+                    class="sc-fAUdSK iwDUbw"
                     role="search"
                     slot="search"
                     value="search"
@@ -162,11 +162,11 @@ exports[`Table > Snapshots > Should match the snapshot when searchable 1`] = `
               Column 1
               <div
                 aria-expanded="true"
-                class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
               >
                 <input
                   aria-label="Search a"
-                  class="sc-fAUdSK cfCVRY"
+                  class="sc-fAUdSK iwDUbw"
                   role="search"
                   slot="search"
                   value="search"
@@ -345,11 +345,11 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
                 Column 1
                 <div
                   aria-expanded="false"
-                  class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                  class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
                 >
                   <input
                     aria-label="Search a"
-                    class="sc-fAUdSK cfCVRY"
+                    class="sc-fAUdSK iwDUbw"
                     disabled=""
                     role="search"
                     slot="search"
@@ -483,11 +483,11 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
               Column 1
               <div
                 aria-expanded="false"
-                class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
               >
                 <input
                   aria-label="Search a"
-                  class="sc-fAUdSK cfCVRY"
+                  class="sc-fAUdSK iwDUbw"
                   disabled=""
                   role="search"
                   slot="search"
@@ -678,11 +678,11 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
                 Column 1
                 <div
                   aria-expanded="false"
-                  class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                  class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
                 >
                   <input
                     aria-label="Search a"
-                    class="sc-fAUdSK cfCVRY"
+                    class="sc-fAUdSK iwDUbw"
                     disabled=""
                     role="search"
                     slot="search"
@@ -1947,11 +1947,11 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
               Column 1
               <div
                 aria-expanded="false"
-                class="sc-dntaoT hZvNeh aje-combo-input sc-bbQqnZ jOVqkt padding-left"
+                class="sc-dntaoT hLviyf aje-combo-input sc-bbQqnZ jOVqkt"
               >
                 <input
                   aria-label="Search a"
-                  class="sc-fAUdSK cfCVRY"
+                  class="sc-fAUdSK iwDUbw"
                   disabled=""
                   role="search"
                   slot="search"

--- a/packages/atomic-elements/src/components/Layout/Table/components/TableColumn.tsx
+++ b/packages/atomic-elements/src/components/Layout/Table/components/TableColumn.tsx
@@ -176,7 +176,7 @@ export function TableColumnWrapper<T extends object>(
             )}
             {allowsSearching && (
               <>
-                <SearchComboInput aria-expanded={isSearching} padding={"left"}>
+                <SearchComboInput aria-expanded={isSearching} padding="left">
                   <Input slot="search" />
                   <IconButton
                     icon="close"

--- a/packages/atomic-elements/src/styles/mixins.ts
+++ b/packages/atomic-elements/src/styles/mixins.ts
@@ -57,7 +57,8 @@ const mixins = {
     }
   `,
   InputLike: css`
-    border: var(--input-border);
+    border-style: var(--input-border-style);
+    border-width: var(--input-border-width);
     border-color: var(--input-border-clr);
     border-radius: var(--input-border-radius);
     min-height: var(--input-height);
@@ -112,11 +113,11 @@ const mixins = {
       border-color: var(--error700);
     }
   `,
-  Border: (prefix: string, style: string) => css`
+  Border: (prefix: string, style: string = "solid") => css`
     border-width: var(--${prefix}-border-width);
     border-color: var(--${prefix}-border-clr);
-    border-style: ${style};
-    border-radius: var(--${prefix}-radius, 0);
+    border-style: var(--${prefix}-border-style, ${style});
+    border-radius: var(--${prefix}-border-radius, 0);
   `,
 };
 

--- a/packages/atomic-elements/src/styles/variables.ts
+++ b/packages/atomic-elements/src/styles/variables.ts
@@ -101,6 +101,11 @@ export const CssVariables = createGlobalStyle`
 
   /* # Input */
   --input-border-clr: var(--neutral300);
+  --input-border-width: 1px;
+  --input-border-style: solid;
+  --input-border-radius: var(--radius);
+  --input-border: 1px solid var(--input-border-clr);
+
   --input-outline: 1px solid var(--outline-clr-primary);
   --input-height: 40px;
   --input-padding-horiz: 12px;
@@ -109,8 +114,6 @@ export const CssVariables = createGlobalStyle`
   --input-icon-size: 2.4rem;
   --input-icon-clr: var(--neutral600);
   --input-text-clr: var(--text-clr);
-  --input-border: 1px solid var(--input-border-clr);
-  --input-border-radius: var(--radius);
   --input-bg-clr: none;
   --input-transition: none;
 
@@ -232,7 +235,7 @@ export const CssVariables = createGlobalStyle`
   --popover-distance: 5px;
 
   /* # CheckBox */
-  --checkbox-radius: var(--radius);
+  --checkbox-border-radius: var(--radius);
   --checkbox-checked: var(--accent-clr);
   --checkbox-border-clr: var(--neutral600);
   --checkbox-border-width: 2px;
@@ -245,7 +248,7 @@ export const CssVariables = createGlobalStyle`
   --checkbox-label-height: 24px;
 
   /* # Radio */
-  --radio-radius: 50%;
+  --radio-border-radius: 50%;
   --radio-checked: var(--accent-clr);
   --radio-border-clr: var(--neutral600);
   --radio-border-width: 2px;

--- a/packages/atomic-elements/src/styles/variables.ts
+++ b/packages/atomic-elements/src/styles/variables.ts
@@ -7,10 +7,15 @@ export const CssVariables = createGlobalStyle`
   /* # General */
 
   /* ## Borders */
-  --border: 1px solid var(--border-clr-primary);
-  --outline: 2px solid var(--outline-clr-primary);
+  --border-width: 1px;
+  --border-style: solid;
   --border-clr-primary: var(--neutral300);
+  --border: var(--border-width) var(--border-style) var(--border-clr-primary);
+
+  --outline-width: 2px;
+  --oultin-style: solid;
   --outline-clr-primary: var(--neutral600);
+  --outline: var(--outline-width) var(--outline-style) var(--outline-clr-primary);
   --radius: 5px;
 
   /* ## Fonts */
@@ -100,12 +105,11 @@ export const CssVariables = createGlobalStyle`
   --size-full-y: 100%;
 
   /* # Input */
-  --input-border-clr: var(--neutral300);
-  --input-border-width: 1px;
-  --input-border-style: solid;
+  --input-border-clr: var(--border-clr-primary);
+  --input-border-width: var(--border-width);
+  --input-border-style: var(--border-style);
   --input-border-radius: var(--radius);
   --input-border: 1px solid var(--input-border-clr);
-
   --input-outline: 1px solid var(--outline-clr-primary);
   --input-height: 40px;
   --input-padding-horiz: 12px;

--- a/playground/src/tabs/Fields.tsx
+++ b/playground/src/tabs/Fields.tsx
@@ -78,7 +78,7 @@ export default function Fields() {
       >
         <FieldLabel>Label</FieldLabel>
         <FieldMessage>Message</FieldMessage>
-        <ComboInput>
+        <ComboInput padding="both">
           <MaterialIcon icon="search" />
           <FieldInput placeholder="placeholder" />
         </ComboInput>


### PR DESCRIPTION
Improved storybook development by importing Elements components directly
instead of from the package `@atomicjolt/atomic-elements` which required
a build when things changed in some circumstances

Changed `ComboInput` `padding` prop to take "both" as an option #68 

Tweaked the styles for input components so that they use the same CSS
variables consistently for borders & outlines. Sometimes they weren't consistent