### PR TITLE
fix(elements): only pass DOM props to anchor tag in Link component

### DIFF
--- a/.changeset/lemon-boxes-deliver.md
+++ b/.changeset/lemon-boxes-deliver.md
@@ -1,0 +1,5 @@
+---
+"@atomicjolt/atomic-elements": patch
+---
+
+fix: stop passing non-dom props to anchor tag in Link prop

--- a/packages/atomic-elements/src/components/Typography/Link/Link.component.tsx
+++ b/packages/atomic-elements/src/components/Typography/Link/Link.component.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { useLink, AriaLinkOptions } from "@react-aria/link";
-import { mergeProps } from "@react-aria/utils";
+import { filterDOMProps, mergeProps } from "@react-aria/utils";
 import { DomProps, RenderBaseProps } from "../../../types";
 import { TypographyProps } from "@styles/typography";
 import { MarginProps } from "@styles/layout";
@@ -45,7 +45,7 @@ export function Link(props: LinkProps) {
       ref={ref}
       as={as}
       {...mergeProps(linkProps, renderProps)}
-      {...rest}
+      {...filterDOMProps(rest)}
     >
       {renderProps.children}
     </StyledLink>


### PR DESCRIPTION
fixes #110 