### PR TITLE
Icon Focus

### DIFF
--- a/packages/atomic-elements/src/components/Banners/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Banners/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -164,7 +164,6 @@ exports[`Banner > Banner.IconButton > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-fLDLck hYHdiZ aje-icon material-icons is-medium"
-          tabindex="0"
         >
           more_vert
         </i>
@@ -181,7 +180,6 @@ exports[`Banner > Banner.IconButton > should match snapshot 1`] = `
       <i
         aria-hidden="true"
         class="sc-fLDLck hYHdiZ aje-icon material-icons is-medium"
-        tabindex="0"
       >
         more_vert
       </i>

--- a/packages/atomic-elements/src/components/Banners/DismissableBanner/__snapshots__/DismissableBanner.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Banners/DismissableBanner/__snapshots__/DismissableBanner.spec.tsx.snap
@@ -21,7 +21,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot 1`] = `
           <i
             aria-hidden="true"
             class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-            tabindex="0"
           >
             close
           </i>
@@ -46,7 +45,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           close
         </i>
@@ -118,7 +116,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot with icon 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           info
         </i>
@@ -135,7 +132,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot with icon 1`] = `
           <i
             aria-hidden="true"
             class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-            tabindex="0"
           >
             close
           </i>
@@ -150,7 +146,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot with icon 1`] = `
       <i
         aria-hidden="true"
         class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-        tabindex="0"
       >
         info
       </i>
@@ -167,7 +162,6 @@ exports[`DismissableBanner > Snapshots > should match snapshot with icon 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           close
         </i>
@@ -239,7 +233,6 @@ exports[`ErrorBanner > Snapshots > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           error
         </i>
@@ -256,7 +249,6 @@ exports[`ErrorBanner > Snapshots > should match snapshot 1`] = `
           <i
             aria-hidden="true"
             class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-            tabindex="0"
           >
             close
           </i>
@@ -271,7 +263,6 @@ exports[`ErrorBanner > Snapshots > should match snapshot 1`] = `
       <i
         aria-hidden="true"
         class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-        tabindex="0"
       >
         error
       </i>
@@ -288,7 +279,6 @@ exports[`ErrorBanner > Snapshots > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           close
         </i>
@@ -360,7 +350,6 @@ exports[`WarningBanner > Snapshots > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           warning
         </i>
@@ -377,7 +366,6 @@ exports[`WarningBanner > Snapshots > should match snapshot 1`] = `
           <i
             aria-hidden="true"
             class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-            tabindex="0"
           >
             close
           </i>
@@ -392,7 +380,6 @@ exports[`WarningBanner > Snapshots > should match snapshot 1`] = `
       <i
         aria-hidden="true"
         class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-        tabindex="0"
       >
         warning
       </i>
@@ -409,7 +396,6 @@ exports[`WarningBanner > Snapshots > should match snapshot 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           close
         </i>

--- a/packages/atomic-elements/src/components/Buttons/IconButton/__snapshots__/IconButton.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Buttons/IconButton/__snapshots__/IconButton.spec.tsx.snap
@@ -12,7 +12,6 @@ exports[`matches snapshot 1`] = `
     <i
       aria-hidden="true"
       class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-      tabindex="0"
     >
       more_vert
     </i>

--- a/packages/atomic-elements/src/components/Content/Disclosure/__snapshots__/Disclosure.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Content/Disclosure/__snapshots__/Disclosure.spec.tsx.snap
@@ -16,7 +16,6 @@ exports[`Disclosure > Single Disclosure > matches snapshot 1`] = `
       <i
         aria-hidden="true"
         class="sc-deSjom eSWOt aje-icon material-icons is-medium"
-        tabindex="0"
       >
         expand_more
       </i>

--- a/packages/atomic-elements/src/components/Content/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Content/Table/__snapshots__/Table.spec.tsx.snap
@@ -59,7 +59,6 @@ exports[`Table > Snapshots > Should match the snapshot when searchable 1`] = `
                     <i
                       aria-hidden="true"
                       class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                      tabindex="0"
                     >
                       close
                     </i>
@@ -205,7 +204,6 @@ exports[`Table > Snapshots > Should match the snapshot when searchable 1`] = `
                   <i
                     aria-hidden="true"
                     class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                    tabindex="0"
                   >
                     close
                   </i>
@@ -408,7 +406,6 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
                     <i
                       aria-hidden="true"
                       class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                      tabindex="0"
                     >
                       close
                     </i>
@@ -423,7 +420,6 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
                   <i
                     aria-hidden="true"
                     class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                    tabindex="0"
                   >
                     search
                   </i>
@@ -568,7 +564,6 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
                   <i
                     aria-hidden="true"
                     class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                    tabindex="0"
                   >
                     close
                   </i>
@@ -583,7 +578,6 @@ exports[`Table > Snapshots > should match the snapshot 1`] = `
                 <i
                   aria-hidden="true"
                   class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                  tabindex="0"
                 >
                   search
                 </i>
@@ -785,7 +779,6 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
                     <i
                       aria-hidden="true"
                       class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                      tabindex="0"
                     >
                       close
                     </i>
@@ -800,7 +793,6 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
                   <i
                     aria-hidden="true"
                     class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                    tabindex="0"
                   >
                     search
                   </i>
@@ -2068,7 +2060,6 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
                   <i
                     aria-hidden="true"
                     class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                    tabindex="0"
                   >
                     close
                   </i>
@@ -2083,7 +2074,6 @@ exports[`Table > Snapshots > should match the snapshot when in a loading state 1
                 <i
                   aria-hidden="true"
                   class="sc-kfeOyU ceGEEk aje-icon material-icons is-small"
-                  tabindex="0"
                 >
                   search
                 </i>

--- a/packages/atomic-elements/src/components/Dropdowns/Combobox/__snapshots__/Combobox.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Dropdowns/Combobox/__snapshots__/Combobox.spec.tsx.snap
@@ -53,7 +53,6 @@ exports[`matches snapshots > matches default variant 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-auto"
-          tabindex="0"
         >
           search
         </i>
@@ -106,7 +105,6 @@ exports[`matches snapshots > matches floating variant 1`] = `
           <i
             aria-hidden="true"
             class="sc-FEMpB jyuubH aje-icon material-icons is-auto"
-            tabindex="0"
           >
             search
           </i>

--- a/packages/atomic-elements/src/components/Dropdowns/CustomSelect/__snapshots__/CustomSelect.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Dropdowns/CustomSelect/__snapshots__/CustomSelect.spec.tsx.snap
@@ -57,7 +57,6 @@ exports[`matches snapshots > matches default variant 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>
@@ -118,7 +117,6 @@ exports[`matches snapshots > matches floating variant 1`] = `
         <i
           aria-hidden="true"
           class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-          tabindex="0"
         >
           arrow_drop_down
         </i>

--- a/packages/atomic-elements/src/components/Dropdowns/MultiSelect/__snapshots__/MultiSelect.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Dropdowns/MultiSelect/__snapshots__/MultiSelect.spec.tsx.snap
@@ -28,7 +28,6 @@ exports[`MultiSelect > matches default variant 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>
@@ -60,7 +59,6 @@ exports[`MultiSelect > matches floating variant 1`] = `
         <i
           aria-hidden="true"
           class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-          tabindex="0"
         >
           arrow_drop_down
         </i>

--- a/packages/atomic-elements/src/components/Feedback/LoadingStatus/__snapshots__/LoadingStatus.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Feedback/LoadingStatus/__snapshots__/LoadingStatus.spec.tsx.snap
@@ -8,7 +8,6 @@ exports[`LoadingStatus > matches error snapshot 1`] = `
     <i
       aria-hidden="true"
       class="sc-gNZgCX gypsPY aje-icon material-icons is-medium"
-      tabindex="0"
     >
       error
     </i>
@@ -27,7 +26,6 @@ exports[`LoadingStatus > matches error snapshot 1`] = `
       <i
         aria-hidden="true"
         class="sc-gNZgCX gypsPY aje-icon material-icons is-medium"
-        tabindex="0"
       >
         close
       </i>

--- a/packages/atomic-elements/src/components/Fields/MultiSelectField/__snapshots__/MultiSelectField.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Fields/MultiSelectField/__snapshots__/MultiSelectField.spec.tsx.snap
@@ -21,7 +21,6 @@ exports[`MultiSelectField > matches snapshots > when closed 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>
@@ -53,7 +52,6 @@ exports[`MultiSelectField > matches snapshots > when open 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>

--- a/packages/atomic-elements/src/components/Fields/SelectField/__snapshots__/SelectField.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Fields/SelectField/__snapshots__/SelectField.spec.tsx.snap
@@ -54,7 +54,6 @@ exports[`SelectField > matches snapshots > when closed 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>
@@ -119,7 +118,6 @@ exports[`SelectField > matches snapshots > when open 1`] = `
       <i
         aria-hidden="true"
         class="sc-jBIHhB dShSRo aje-icon material-icons is-medium"
-        tabindex="0"
       >
         arrow_drop_down
       </i>

--- a/packages/atomic-elements/src/components/Icons/MaterialIcon/MaterialIcon.component.tsx
+++ b/packages/atomic-elements/src/components/Icons/MaterialIcon/MaterialIcon.component.tsx
@@ -31,6 +31,7 @@ export const MaterialIcon = React.forwardRef<HTMLElement, MaterialIconProps>(
       size = "medium",
       disabled = false,
       isDisabled = disabled,
+      isFocusable = false,
       style,
       ...rest
     } = props;
@@ -50,18 +51,18 @@ export const MaterialIcon = React.forwardRef<HTMLElement, MaterialIconProps>(
       },
     });
 
-    // We use the focusable hook so that the icon supports tooltips
-    // when the icon itself isn't actually focusable
+    const componentProps = [filterDOMProps(rest), renderProps];
+
     const { focusableProps } = useFocusable({}, ref);
 
-    const componentProps = mergeProps(
-      filterDOMProps(rest),
-      renderProps,
-      focusableProps
-    );
+    if (isFocusable) {
+      componentProps.push(focusableProps);
+    }
+
+    const mergedProps = mergeProps(...componentProps);
 
     return (
-      <StyledIcon ref={ref} aria-hidden {...componentProps}>
+      <StyledIcon ref={ref} aria-hidden {...mergedProps}>
         {icon}
       </StyledIcon>
     );

--- a/packages/atomic-elements/src/components/Icons/MaterialIcon/MaterialIcon.spec.tsx
+++ b/packages/atomic-elements/src/components/Icons/MaterialIcon/MaterialIcon.spec.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MaterialIcon } from "./MaterialIcon.component";
+
+describe("MaterialIcon", () => {
+  it("renders correctly", () => {
+    const { container } = render(<MaterialIcon icon="home" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should not be focusable by default", () => {
+    render(<MaterialIcon icon="home" />);
+    const icon = screen.getByText("home");
+    expect(icon.tabIndex).toBe(-1);
+  });
+
+  it("should be focusable when isFocusable is true", () => {
+    render(<MaterialIcon icon="home" isFocusable />);
+    const icon = screen.getByText("home");
+    expect(icon.tabIndex).toBe(0);
+  });
+});

--- a/packages/atomic-elements/src/components/Icons/MaterialIcon/__snapshots__/MaterialIcon.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Icons/MaterialIcon/__snapshots__/MaterialIcon.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MaterialIcon > renders correctly 1`] = `
+<div>
+  <i
+    aria-hidden="true"
+    class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
+  >
+    home
+  </i>
+</div>
+`;

--- a/packages/atomic-elements/src/components/Icons/MaterialSymbol/MaterialSymbol.component.tsx
+++ b/packages/atomic-elements/src/components/Icons/MaterialSymbol/MaterialSymbol.component.tsx
@@ -32,6 +32,7 @@ export const MaterialSymbol = React.forwardRef<
     variant = "outlined",
     size = "medium",
     isDisabled = false,
+    isFocusable = false,
     style,
     weight,
     grade,
@@ -61,24 +62,24 @@ export const MaterialSymbol = React.forwardRef<
     opticalSize,
   });
 
-  // We use the focusable hook so that the icon supports tooltips
-  // the icon itself isn't actually focusable
+  const componentProps = [filterDOMProps(rest), renderProps];
+
   const { focusableProps } = useFocusable({}, ref);
 
-  const componentProps = mergeProps(
-    filterDOMProps(rest),
-    renderProps,
-    focusableProps
-  );
+  if (isFocusable) {
+    componentProps.push(focusableProps);
+  }
+
+  const mergedProps = mergeProps(...componentProps);
 
   return (
     <StyledIcon
       ref={ref}
       aria-hidden
-      {...componentProps}
+      {...mergedProps}
       style={{
         fontVariationSettings: fontVariationSettings || undefined,
-        ...componentProps.style,
+        ...mergedProps.style,
       }}
     >
       {symbol}

--- a/packages/atomic-elements/src/components/Icons/MaterialSymbol/MaterialSymbol.spec.tsx
+++ b/packages/atomic-elements/src/components/Icons/MaterialSymbol/MaterialSymbol.spec.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MaterialSymbol } from "./MaterialSymbol.component";
+
+describe("MaterialSymbol", () => {
+  it("renders correctly", () => {
+    const { container } = render(<MaterialSymbol symbol="home" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it("should not be focusable by default", () => {
+    render(<MaterialSymbol symbol="home" />);
+    const icon = screen.getByText("home");
+    expect(icon.tabIndex).toBe(-1);
+  });
+
+  it("should be focusable when isFocusable is true", () => {
+    render(<MaterialSymbol symbol="home" isFocusable />);
+    const icon = screen.getByText("home");
+    expect(icon.tabIndex).toBe(0);
+  });
+});

--- a/packages/atomic-elements/src/components/Icons/MaterialSymbol/__snapshots__/MaterialSymbol.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Icons/MaterialSymbol/__snapshots__/MaterialSymbol.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MaterialSymbol > renders correctly 1`] = `
+<div>
+  <i
+    aria-hidden="true"
+    class="sc-FEMpB jyuubH aje-icon material-symbols-outlined is-medium"
+  >
+    home
+  </i>
+</div>
+`;

--- a/packages/atomic-elements/src/components/Inputs/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Inputs/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -32,7 +32,6 @@ exports[`matches snapshot > displays with search button 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           search
         </i>
@@ -74,7 +73,6 @@ exports[`matches snapshot > displays without button 1`] = `
         <i
           aria-hidden="true"
           class="sc-FEMpB jyuubH aje-icon material-icons is-medium"
-          tabindex="0"
         >
           search
         </i>

--- a/packages/atomic-elements/src/components/Overlays/ToolTip/ToolTip.stories.tsx
+++ b/packages/atomic-elements/src/components/Overlays/ToolTip/ToolTip.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<ToolTipProps & ToolTipTriggerProps> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "centered",
-    cssprops: getCssProps("ToolTip"),
+    cssprops: getCssProps("Tooltip"),
   },
   argTypes: {
     // @ts-ignore
@@ -153,6 +153,8 @@ export const IconWithTooltip: Story = {
   ...Primary,
   args: {
     ...Primary.args,
-    target: <MaterialIcon icon="info" size="large" variant="outlined" />,
+    target: (
+      <MaterialIcon icon="info" size="large" variant="outlined" isFocusable />
+    ),
   },
 };

--- a/packages/atomic-elements/src/types/icons.ts
+++ b/packages/atomic-elements/src/types/icons.ts
@@ -15,6 +15,7 @@ export interface IconComponentBase<T extends object>
     RenderBaseProps<T> {
   size?: ExtendedSize;
   isDisabled?: boolean;
+  isFocusable?: boolean;
 }
 
 export type MaterialIconVariants =


### PR DESCRIPTION
Adds an `isFocusable` props to icon components that defaults to off. When it's enabled the icon becomes focusable via keyboard navigation. They were focusable by default before which wasn't the intended behavior

An Icon needs to be focusable to be the target of a tooltip