### PR TITLE
fix: add help_outline icon to MaterialIcons type

### DIFF
--- a/packages/atomic-elements/src/types/icons.ts
+++ b/packages/atomic-elements/src/types/icons.ts
@@ -25,6 +25,7 @@ export type MaterialIconVariants =
   | "two-tone";
 
 export type MaterialIcons =
+  | "help_outline"
   | "push_pin"
   | "clear"
   | "search"


### PR DESCRIPTION
closes #162 
