### PR TITLE
Modal Placement

### DIFF
--- a/.changeset/sharp-lands-act.md
+++ b/.changeset/sharp-lands-act.md
@@ -1,0 +1,5 @@
+---
+"@atomicjolt/atomic-elements": minor
+---
+
+add ensureVisible prop to Modal component

--- a/packages/atomic-elements/src/components/Overlays/Modal/Modal.component.tsx
+++ b/packages/atomic-elements/src/components/Overlays/Modal/Modal.component.tsx
@@ -3,8 +3,8 @@ import { AriaModalOverlayProps, useModalOverlay } from "@react-aria/overlays";
 import { OverlayTriggerState, useOverlayTriggerState } from "react-stately";
 
 import { useContextProps } from "@hooks/useContextProps";
-import { OverlayTriggerStateContext } from "../OverlayTrigger/context";
 import { useRenderProps } from "@hooks/useRenderProps";
+import { OverlayTriggerStateContext } from "../OverlayTrigger/context";
 
 import { BaseModalProps, ModalChildren } from "./Modal.types";
 import { ModalContext } from "./Modal.context";
@@ -14,6 +14,7 @@ import { ModalHeader } from "./components/ModalHeader";
 import { ModalTitle } from "./components/ModalTitle";
 import { ModalBody } from "./components/ModalBody";
 import { ModalFooter } from "./components/ModalFooter";
+import { useManageModalScroll } from "./hooks/useManageModalScroll";
 
 export interface ModalProps extends BaseModalProps {
   children?: ModalChildren;
@@ -58,10 +59,24 @@ function ModalInternal(props: ModalInternalProps) {
     isCentered,
     isOpen,
     triggerRef,
+    ensureVisible,
     ...rest
   } = props;
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement | null>(null);
   const { modalProps, underlayProps } = useModalOverlay(props, state, ref);
+
+  useManageModalScroll(
+    {
+      ensureVisible,
+      modalRef: ref,
+      scrollOptions: {
+        behavior: "instant",
+        block: "end",
+        inline: "nearest",
+      },
+    },
+    state
+  );
 
   const renderProps = useRenderProps({
     componentClassName: "aje-modal",
@@ -75,7 +90,7 @@ function ModalInternal(props: ModalInternalProps) {
       <ModalWrapper
         onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}
         ref={ref}
-        $isCentered={isCentered}
+        data-placement={isCentered ? "center" : "top"}
         {...rest}
         {...modalProps}
         {...renderProps}

--- a/packages/atomic-elements/src/components/Overlays/Modal/Modal.context.ts
+++ b/packages/atomic-elements/src/components/Overlays/Modal/Modal.context.ts
@@ -1,4 +1,4 @@
 import { ModalProps } from ".";
-import { createComponentContext } from '@utils/index';
+import { createComponentContext } from "@utils/index";
 
 export const ModalContext = createComponentContext<ModalProps>();

--- a/packages/atomic-elements/src/components/Overlays/Modal/Modal.styles.ts
+++ b/packages/atomic-elements/src/components/Overlays/Modal/Modal.styles.ts
@@ -1,13 +1,16 @@
-import { layout, LayoutProps } from '@styles/layout';
+import { layout, LayoutProps } from "@styles/layout";
 import styled from "styled-components";
 
-export const ModalWrapper = styled.div<LayoutProps & { $isCentered?: boolean }>`
-  ${({ $isCentered }) => !$isCentered && "margin-top: 58px;" }
-  ${layout.defaults({ $width: "100%", $maxWidth: "800px", $p: "5" })};
-
+export const ModalWrapper = styled.div<LayoutProps>`
   border-radius: calc(var(--radius) * 2);
   background-color: var(--neutral50);
   box-shadow: 0 10px 40px hsla(0, 0%, 0%, 0.25);
+
+  &[data-placement="top"] {
+    margin-top: 58px;
+  }
+
+  ${layout.defaults({ $width: "100%", $maxWidth: "800px", $p: "5" })};
 `;
 
 export const ModalBackground = styled.div`

--- a/packages/atomic-elements/src/components/Overlays/Modal/Modal.types.ts
+++ b/packages/atomic-elements/src/components/Overlays/Modal/Modal.types.ts
@@ -18,4 +18,15 @@ export interface BaseModalProps
 
   /** Centers the modal within the viewport */
   isCentered?: boolean;
+
+  /** Ensures the modal is visible by scrolling it into view.
+   *
+   * This is typically unnecessary since modals are automatically
+   * centered in the browser viewport. However, when rendering
+   * within an iframe that exceeds the parent viewport height,
+   * the optimal placement cannot be determined. In this case,
+   * the modal is positioned at the top of the page and
+   * automatically scrolled into view.
+   */
+  ensureVisible?: boolean;
 }

--- a/packages/atomic-elements/src/components/Overlays/Modal/hooks/useManageModalScroll.ts
+++ b/packages/atomic-elements/src/components/Overlays/Modal/hooks/useManageModalScroll.ts
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef } from "react";
+import { OverlayTriggerState } from "react-stately";
+
+interface UseManageModalScrollProps {
+  ensureVisible?: boolean;
+  modalRef: React.RefObject<HTMLElement | null>;
+  scrollOptions?: boolean | ScrollIntoViewOptions;
+}
+
+/**
+ * Custom hook that manages modal scrolling behavior and focus restoration.
+ *
+ * When the modal opens and `ensureVisible` is true, this hook will:
+ * - Store the currently focused element
+ * - Scroll the modal into view using the provided scroll options
+ *
+ * When the modal closes or the component unmounts, it will:
+ * - Restore focus to the previously focused element
+ * - Reset the stored focus reference
+ */
+export function useManageModalScroll(
+  props: UseManageModalScrollProps,
+  state: OverlayTriggerState
+) {
+  const { modalRef, ensureVisible, scrollOptions } = props;
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (state.isOpen && ensureVisible) {
+      previousFocus.current = document.activeElement as HTMLElement | null;
+      modalRef.current?.scrollIntoView(scrollOptions);
+    }
+
+    return () => {
+      // Restore previous focus, which will move the page back to where it was.
+      // 99% of the time this will be the element that was focused before the modal opened.
+      previousFocus.current?.focus();
+      previousFocus.current = null;
+    };
+  }, [state.isOpen, ensureVisible]);
+}

--- a/packages/atomic-elements/src/components/Overlays/Modal/index.tsx
+++ b/packages/atomic-elements/src/components/Overlays/Modal/index.tsx
@@ -1,3 +1,4 @@
 export { Modal } from "./Modal.component";
+export { ModalContext } from "./Modal.context";
 export type { ModalProps } from "./Modal.component";
 export type { BaseModalProps } from "./Modal.types";

--- a/packages/atomic-elements/src/components/Overlays/OverlayTrigger/OverlayTrigger.component.tsx
+++ b/packages/atomic-elements/src/components/Overlays/OverlayTrigger/OverlayTrigger.component.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useContext, useRef } from "react";
 import { useOverlayTrigger } from "@react-aria/overlays";
 import { PressResponder } from "@react-aria/interactions";
 import {
@@ -24,6 +24,7 @@ export interface OverlayTriggerProps
  * */
 export function OverlayTrigger(props: OverlayTriggerProps) {
   const state = useOverlayTriggerState(props);
+  const parentModalContext = useContext(ModalContext);
   const ref = useRef<HTMLElement>(null);
   const { type = "dialog" } = props;
   const { overlayProps, triggerProps } = useOverlayTrigger(
@@ -44,6 +45,7 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
           ModalContext.Provider,
           {
             triggerRef: ref,
+            ...parentModalContext,
             ...overlayProps,
           },
         ],

--- a/packages/atomic-elements/src/components/index.ts
+++ b/packages/atomic-elements/src/components/index.ts
@@ -27,7 +27,7 @@ export {
 export { OverlayTrigger } from "./Overlays/OverlayTrigger";
 export { Pressable } from "./Overlays/OverlayTrigger/Pressable";
 export { ToolTipTrigger, ToolTip, ToolTipTarget } from "./Overlays/ToolTip";
-export { Modal } from "./Overlays/Modal";
+export { Modal, ModalContext } from "./Overlays/Modal";
 export { ConfirmationModal } from "./Overlays/ConfirmationModal";
 export { ErrorModal } from "./Overlays/ErrorModal";
 export { Popover } from "./Overlays/Popover";


### PR DESCRIPTION
Adds `ensureVisible` prop to Modal component. When this is true, the Modal will always be scrolled into view when it is rendered. 

This is typically unnecessary since modals are automatically centered in the browser viewport. However, when rendering within an iframe that exceeds the parent viewport height, the optimal placement cannot be determined. In this case, the modal is positioned at the top of the page and automatically scrolled into view.

This PR also exposes the `ModalContext` for importing, which allows one to set this (and other modal props) globally. 

```tsx
<ModalContext value={{ ensureVisible: true }}>
   Render you app here
</ModalContext>
```