### PR TITLE
fix: Properly support links for chips

### DIFF
--- a/.changeset/wide-trains-design.md
+++ b/.changeset/wide-trains-design.md
@@ -1,0 +1,6 @@
+---
+"@atomicjolt/atomic-elements": patch
+---
+
+Standalone Chips and ChipGroup Chips now proplerly support being turned into links
+by setting the `href` prop.

--- a/packages/atomic-elements/src/components/Chips/Chip/Chip.component.tsx
+++ b/packages/atomic-elements/src/components/Chips/Chip/Chip.component.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { filterDOMProps, mergeProps, useObjectRef } from "@react-aria/utils";
 import { useTag } from "@react-aria/tag";
 import { createLeafComponent } from "@react-aria/collections";
+import { useLink } from "@react-aria/link";
 
 import { IconButton } from "@components/Buttons/IconButton";
 import { useConditionalPress } from "@hooks/useConditionalPress";
@@ -62,11 +63,21 @@ function ChipGroupChip<T>(props: ChipGroupChipProps<T>) {
     ...props,
   });
 
+  const { linkProps } = useLink(props, ref as any);
+
+  const mergedProps = mergeProps(
+    rowProps,
+    focusProps,
+    props.href ? linkProps : {}
+  );
+
   return (
     <ChipWrapper
       ref={ref}
-      {...mergeProps(rowProps, focusProps)}
+      as={props.href ? "a" : "div"}
+      {...mergedProps}
       {...renderProps}
+      {...filterDOMProps(props as any)}
     >
       <ChipContent {...gridCellProps}>
         {renderProps.children}
@@ -99,6 +110,8 @@ export const ChipInternal = React.forwardRef(function ChipInternal<T>(
 
   const { pressProps } = useConditionalPress(rest);
 
+  const { linkProps } = useLink(props, ref as any);
+
   const renderProps = useRenderProps({
     componentClassName: "aje-chip",
     values: {
@@ -109,10 +122,19 @@ export const ChipInternal = React.forwardRef(function ChipInternal<T>(
     ...props,
   });
 
+  const mergedProps = mergeProps(
+    {
+      "aria-disabled": isDisabled || undefined,
+    },
+    pressProps,
+    props.href ? linkProps : {}
+  );
+
   return (
     <ChipWrapper
+      as={props.href ? "a" : "div"}
       ref={ref}
-      {...mergeProps({ "aria-disabled": isDisabled || undefined }, pressProps)}
+      {...mergedProps}
       {...renderProps}
       {...filterDOMProps(props as any)}
     >

--- a/packages/atomic-elements/src/components/Chips/Chip/Chip.spec.tsx
+++ b/packages/atomic-elements/src/components/Chips/Chip/Chip.spec.tsx
@@ -14,4 +14,10 @@ describe("Chip", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(onRemove).toHaveBeenCalledOnce();
   });
+
+  test("Can be rendered as a link", () => {
+    render(<Chip href="/test">Item</Chip>);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/test");
+  });
 });

--- a/packages/atomic-elements/src/components/Chips/Chip/Chip.styles.ts
+++ b/packages/atomic-elements/src/components/Chips/Chip/Chip.styles.ts
@@ -37,6 +37,8 @@ export const ChipWrapper = styled.div`
   color: var(--chip-text-clr);
   border-radius: var(--chip-radius);
   border: var(--chip-border);
+  text-decoration: none;
+  cursor: default;
 
   &.aje-chip--success {
     --chip-bg-clr: var(--success100);
@@ -63,7 +65,8 @@ export const ChipWrapper = styled.div`
   }
 
   &[role="button"]:hover,
-  &[aria-selected]:hover {
+  &[aria-selected]:hover,
+  &:is(a):hover {
     cursor: pointer;
     --chip-bg-clr: var(--chip-hover-bg-clr);
   }

--- a/packages/atomic-elements/src/components/Chips/Chip/__snapshots__/Chip.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Chips/Chip/__snapshots__/Chip.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Chip > matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="sc-deSjom giYJKr aje-chip"
+    class="sc-deSjom khhqza aje-chip"
   >
     <div
       class="sc-jUkaYT dGjpWu"

--- a/packages/atomic-elements/src/components/Chips/ChipGroup/ChipGroup.spec.tsx
+++ b/packages/atomic-elements/src/components/Chips/ChipGroup/ChipGroup.spec.tsx
@@ -38,4 +38,25 @@ describe("ChipGroup", () => {
       expect(screen.getByText(chip.rendered)).not.toBeNull();
     });
   });
+
+  test("renders chips with href", () => {
+    const chips = [
+      { key: "1", rendered: "Chip 1", href: "/chip1" },
+      { key: "2", rendered: "Chip 2", href: "/chip2" },
+    ];
+    render(
+      <ChipGroup items={chips} label="Label">
+        {({ key, rendered, href }) => (
+          <Chip key={key} href={href}>
+            {rendered}
+          </Chip>
+        )}
+      </ChipGroup>
+    );
+
+    chips.forEach((chip) => {
+      const link = screen.getByRole("row", { name: chip.rendered });
+      expect(link).toHaveAttribute("href", chip.href);
+    });
+  });
 });

--- a/packages/atomic-elements/src/components/Chips/ChipGroup/__snapshots__/ChipGroup.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Chips/ChipGroup/__snapshots__/ChipGroup.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`ChipGroup > matches snapshot 1`] = `
     >
       <div
         aria-label="Item"
-        class="sc-gjXmFk fDQQhF aje-chip"
+        class="sc-gjXmFk eErvzQ aje-chip"
         data-collection="react-aria-:r5:"
         data-key="react-aria-1"
         id="react-aria-:r0:-react-aria-1"

--- a/packages/atomic-elements/src/components/Fields/ChipGroupField/__snapshots__/ChipGroupField.spec.tsx.snap
+++ b/packages/atomic-elements/src/components/Fields/ChipGroupField/__snapshots__/ChipGroupField.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`ChipGroupField > matches snapshot 1`] = `
     >
       <div
         aria-label="Item 1"
-        class="sc-gjXmFk fDQQhF aje-chip"
+        class="sc-gjXmFk eErvzQ aje-chip"
         data-collection="react-aria-:r5:"
         data-key="react-aria-1"
         id="react-aria-:r0:-react-aria-1"
@@ -38,7 +38,7 @@ exports[`ChipGroupField > matches snapshot 1`] = `
       </div>
       <div
         aria-label="Item 2"
-        class="sc-gjXmFk fDQQhF aje-chip"
+        class="sc-gjXmFk eErvzQ aje-chip"
         data-collection="react-aria-:r5:"
         data-key="react-aria-2"
         id="react-aria-:r0:-react-aria-2"
@@ -55,7 +55,7 @@ exports[`ChipGroupField > matches snapshot 1`] = `
       </div>
       <div
         aria-label="Item 3"
-        class="sc-gjXmFk fDQQhF aje-chip"
+        class="sc-gjXmFk eErvzQ aje-chip"
         data-collection="react-aria-:r5:"
         data-key="react-aria-3"
         id="react-aria-:r0:-react-aria-3"


### PR DESCRIPTION
using the `href` property of chips wasn't properly implemented for Chip.

#191 
